### PR TITLE
Moved "Peers length" log to log.info

### DIFF
--- a/consensus/voting/cad_network.go
+++ b/consensus/voting/cad_network.go
@@ -20,7 +20,7 @@ import (
 	//"math"
 	//"strconv"
 	"errors"
-	"fmt"
+	//"fmt"
 	"math/big"
 	"math/rand"
 	"reflect"

--- a/consensus/voting/cad_network.go
+++ b/consensus/voting/cad_network.go
@@ -32,6 +32,7 @@ import (
 	//"github.com/hpb-project/go-hpb/blockchain/storage"
 	"github.com/hpb-project/go-hpb/blockchain/state"
 	"github.com/hpb-project/go-hpb/common"
+	"github.com/hpb-project/go-hpb/common/log"
 	"github.com/hpb-project/go-hpb/network/p2p"
 	"github.com/hpb-project/go-hpb/network/p2p/discover"
 	"math"
@@ -45,7 +46,7 @@ func GetCadNodeFromNetwork(state *state.StateDB) ([]*snapshots.CadWinner, error)
 
 	bestCadWinners := []*snapshots.CadWinner{}
 	peers := p2p.PeerMgrInst().PeersAll()
-	fmt.Println("######### peers length is:", len(peers))
+		log.Info("Peers:", "Connected Peers:", len(peers))
 	if len(peers) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
This is to avoid the log filling up with lines such as the one below if one has set log verbosity level to 1 (only errors):
Oct 05 23:56:55 xxxxxxxxx ghpb[26283]: ######### peers length is: 116

Also improved the wording a bit to "Connected Peers".